### PR TITLE
Vim modeline mantra global fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ virtblkioctl
 # === Generated docs ==========================================================
 doxygen/
 
-# vim:set nu:et:ts=4:sw=4:
+# vim:set nu et ts=4 sw=4:

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,4 +93,4 @@ script:
 
 ...
 
-# vim:set nu:et:ts=4:sw=4:
+# vim:set nu et ts=4 sw=4:

--- a/Doxyfile
+++ b/Doxyfile
@@ -2479,4 +2479,4 @@ GENERATE_LEGEND        = YES
 
 DOT_CLEANUP            = YES
 
-# vim:set nu:et:ts=4:sw=4:
+# vim:set nu et ts=4 sw=4:

--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,4 @@ clean:
 	$(MAKE) $(MAKE_FLAGS)$(TEST_DIR) $(CLN_TARGET)
 	$(RM)   $(RMFLAGS)   $(DOCS_DIR)
 
-# vim:set nu:et:ts=4:sw=4:
+# vim:set nu et ts=4 sw=4:

--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,4 @@ clean:
 	$(MAKE) $(MAKE_FLAGS)$(TEST_DIR) $(CLN_TARGET)
 	$(RM)   $(RMFLAGS)   $(DOCS_DIR)
 
-# vim:set nu et ts=4 sw=4:
+# vim:set nu ts=4 sw=4:

--- a/src/Makefile
+++ b/src/Makefile
@@ -56,4 +56,4 @@ all: default
 clean:
 	$(RM) $(RMFLAGS) $(KMOD).ko $(KMOD).o $(TMPS)
 
-# vim:set nu:et:ts=4:sw=4:
+# vim:set nu et ts=4 sw=4:

--- a/src/Makefile
+++ b/src/Makefile
@@ -56,4 +56,4 @@ all: default
 clean:
 	$(RM) $(RMFLAGS) $(KMOD).ko $(KMOD).o $(TMPS)
 
-# vim:set nu et ts=4 sw=4:
+# vim:set nu ts=4 sw=4:

--- a/src/virtblkiosim.c
+++ b/src/virtblkiosim.c
@@ -837,4 +837,4 @@ MODULE_VERSION     ( _MODULE_VERSION     );
 MODULE_AUTHOR      ( _MODULE_AUTHOR      );
 MODULE_LICENSE     ( _MODULE_LICENSE     );
 
-/* vim:set nu:et:ts=4:sw=4: */
+/* vim:set nu et ts=4 sw=4: */

--- a/src/virtblkiosim.h
+++ b/src/virtblkiosim.h
@@ -219,4 +219,4 @@ struct viosim_request_map {
 
 #endif /* __LINUX__VIRTBLKIOSIM_H */
 
-/* vim:set nu:et:ts=4:sw=4: */
+/* vim:set nu et ts=4 sw=4: */

--- a/tests/ioctl/Makefile
+++ b/tests/ioctl/Makefile
@@ -54,4 +54,4 @@ all: $(EXEC)
 clean:
 	$(RM) $(RMFLAGS) $(EXEC) $(DEPS)
 
-# vim:set nu et ts=4 sw=4:
+# vim:set nu ts=4 sw=4:

--- a/tests/ioctl/Makefile
+++ b/tests/ioctl/Makefile
@@ -54,4 +54,4 @@ all: $(EXEC)
 clean:
 	$(RM) $(RMFLAGS) $(EXEC) $(DEPS)
 
-# vim:set nu:et:ts=4:sw=4:
+# vim:set nu et ts=4 sw=4:

--- a/tests/ioctl/virtblkioctl.c
+++ b/tests/ioctl/virtblkioctl.c
@@ -362,4 +362,4 @@ int main(int argc, char **argv) {
     return ret;
 }
 
-/* vim:set nu:et:ts=4:sw=4: */
+/* vim:set nu et ts=4 sw=4: */

--- a/tests/ioctl/virtblkioctl.h
+++ b/tests/ioctl/virtblkioctl.h
@@ -253,4 +253,4 @@ struct viosim_request_map {
 
 #endif /* __VIRTBLKIOCTL_H */
 
-/* vim:set nu:et:ts=4:sw=4: */
+/* vim:set nu et ts=4 sw=4: */

--- a/tests/iofio/virtblkiofio-00-read.fio
+++ b/tests/iofio/virtblkiofio-00-read.fio
@@ -17,4 +17,4 @@ rw=randread
 blocksize=4k
 iodepth=16
 
-# vim:set nu:et:ts=4:sw=4:
+# vim:set nu et ts=4 sw=4:

--- a/tests/iofio/virtblkiofio-01-write.fio
+++ b/tests/iofio/virtblkiofio-01-write.fio
@@ -17,4 +17,4 @@ rw=randwrite
 blocksize=4k
 iodepth=16
 
-# vim:set nu:et:ts=4:sw=4:
+# vim:set nu et ts=4 sw=4:

--- a/tests/iofio/virtblkiofio-02-both.fio
+++ b/tests/iofio/virtblkiofio-02-both.fio
@@ -27,4 +27,4 @@ rw=randwrite
 blocksize=4k
 iodepth=16
 
-# vim:set nu:et:ts=4:sw=4:
+# vim:set nu et ts=4 sw=4:

--- a/utils/vm-network-setup
+++ b/utils/vm-network-setup
@@ -31,4 +31,4 @@ fi
 
 exit ${EXIT_SUCCESS}
 
-# vim:set nu:et:ts=4:sw=4:
+# vim:set nu et ts=4 sw=4:


### PR DESCRIPTION
Fixing Vim modeline mantra _globally_.
Unsetting **expandtab** in Vim modeline mantra for _Makefiles_.